### PR TITLE
fix: use correct k8s cluster version

### DIFF
--- a/aws-eks/variables.tf
+++ b/aws-eks/variables.tf
@@ -50,7 +50,7 @@ variable "cluster_name" {
 variable "cluster_version" {
   type        = string
   description = "The Kubernetes version to use for the EKS cluster."
-  default     = "~> 19.17.2"
+  default     = "1.28"
 }
 
 variable "min_size" {


### PR DESCRIPTION
Was accidentally swapped with the k8s module version.