### PR TITLE
fix(aws-eks-byovpc): use cluster name instead of install ID

### DIFF
--- a/aws-eks-byovpc/external-dns.tf
+++ b/aws-eks-byovpc/external-dns.tf
@@ -1,6 +1,6 @@
 locals {
   internal_domain = aws_route53_zone.internal.name
-  public_domain = aws_route53_zone.public.name
+  public_domain   = aws_route53_zone.public.name
   external_dns = {
     namespace = "external-dns"
     extra_args = {
@@ -8,7 +8,7 @@ locals {
       1 = "--zone-id-filter=${aws_route53_zone.internal.id}",
       2 = "--zone-id-filter=${aws_route53_zone.public.id}",
     }
-    value_file    = "values/external-dns.yaml"
+    value_file = "values/external-dns.yaml"
   }
 }
 
@@ -17,7 +17,7 @@ module "external_dns_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "~> 5.0"
 
-  role_name = "external-dns-${var.nuon_id}"
+  role_name = "external-dns-${local.install_name}"
 
   attach_external_dns_policy = true
   external_dns_hosted_zone_arns = [
@@ -44,7 +44,7 @@ resource "helm_release" "external_dns" {
 
   set {
     name  = "txt_owner_id"
-    value = var.nuon_id
+    value = local.install_name
   }
 
   set {
@@ -75,7 +75,7 @@ resource "helm_release" "external_dns" {
   ]
 
   depends_on = [
-     module.external_dns_irsa,
-     helm_release.metrics_server
+    module.external_dns_irsa,
+    helm_release.metrics_server
   ]
 }

--- a/aws-eks-byovpc/variables.tf
+++ b/aws-eks-byovpc/variables.tf
@@ -1,6 +1,8 @@
 locals {
 
-  tags = merge({ nuon_id = var.nuon_id }, var.tags)
+  install_name = var.cluster_name
+
+  tags = merge({ nuon_id = local.install_name }, var.tags)
 
   /* external_dns = { */
   /*   registry           = "txt" */
@@ -11,7 +13,7 @@ locals {
   /* } */
 
   vars = {
-    id     = var.nuon_id
+    id     = local.install_name
     region = var.region
   }
 }


### PR DESCRIPTION
I updated the sandbox to allow the customer to set the cluster name, instead of just using the install ID. But, we're still using the install ID in a few other places as the cluster name. I need to parse which places we want the cluster_name, and which places we still want the install ID.