### PR TITLE
fix(aws-eks-byovpc): reimplement vpc outputs

### DIFF
--- a/aws-eks-byovpc/eks.tf
+++ b/aws-eks-byovpc/eks.tf
@@ -65,7 +65,7 @@ module "eks" {
   cluster_endpoint_public_access  = true
 
   vpc_id     = data.aws_vpc.main.id
-  subnet_ids = data.aws_subnets.selected.ids
+  subnet_ids = data.aws_subnets.private.ids
 
   create_kms_key = false
   cluster_encryption_config = {

--- a/aws-eks-byovpc/outputs.tf
+++ b/aws-eks-byovpc/outputs.tf
@@ -18,6 +18,23 @@ output "cluster" {
   }
 }
 
+output "vpc" {
+  // NOTE: these are declared here -
+  // https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest?tab=outputs
+  value = {
+    name = lookup(data.aws_vpc.main.tags, "Name", "")
+    id   = data.aws_vpc.main.id
+    cidr = data.aws_vpc.main.cidr_block
+    azs  = data.aws_availability_zones.available.zone_ids
+
+    private_subnet_cidr_blocks = [for s in data.aws_subnet.private : s.cidr_block]
+    private_subnet_ids         = data.aws_subnets.private.ids
+
+    public_subnet_cidr_blocks = [for s in data.aws_subnet.public : s.cidr_block]
+    public_subnet_ids         = data.aws_subnets.public.ids
+  }
+}
+
 output "account" {
   value = {
     id     = data.aws_caller_identity.current.account_id

--- a/aws-eks-byovpc/vpc.tf
+++ b/aws-eks-byovpc/vpc.tf
@@ -1,7 +1,9 @@
 locals {
-  vpc_id            = var.vpc_id
-  subnets_tag_name  = "kubernetes.io/role/internal-elb"
-  subnets_tag_value = "1"
+  vpc_id                    = var.vpc_id
+  subnets_private_tag_key   = "kubernetes.io/role/internal-elb"
+  subnets_private_tag_value = "1"
+  subnets_public_tag_key    = "kubernetes.io/role/elb"
+  subnets_public_tag_value  = "1"
 }
 
 
@@ -13,14 +15,36 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-data "aws_subnets" "selected" {
+data "aws_subnets" "private" {
   filter {
     name   = "vpc-id"
     values = [local.vpc_id]
   }
 
   filter {
-    name   = "tag:${local.subnets_tag_name}"
-    values = [local.subnets_tag_value]
+    name   = "tag:${local.subnets_private_tag_key}"
+    values = [local.subnets_private_tag_value]
   }
+}
+
+data "aws_subnet" "private" {
+  for_each = toset(data.aws_subnets.private.ids)
+  id       = each.value
+}
+
+data "aws_subnets" "public" {
+  filter {
+    name   = "vpc-id"
+    values = [local.vpc_id]
+  }
+
+  filter {
+    name   = "tag:${local.subnets_public_tag_key}"
+    values = [local.subnets_public_tag_value]
+  }
+}
+
+data "aws_subnet" "public" {
+  for_each = toset(data.aws_subnets.public.ids)
+  id       = each.value
 }


### PR DESCRIPTION
Removed these early on because this sandbox doesn't have a VPC, and updating the outputs was a pain. For backwards compatibility with our provision workflow, though we still need these.