### PR TITLE
refactor(aws-eks-byovpc): remove duplicate local

### DIFF
--- a/aws-eks-byovpc/alb-ingress.tf
+++ b/aws-eks-byovpc/alb-ingress.tf
@@ -8,7 +8,7 @@ module "alb_controller_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "~> 5.0"
 
-  role_name = "alb-controller-${local.vars.id}"
+  role_name = "alb-controller-${local.install_name}"
 
   create_role                            = true
   attach_load_balancer_controller_policy = true

--- a/aws-eks-byovpc/cert-manager.tf
+++ b/aws-eks-byovpc/cert-manager.tf
@@ -9,9 +9,9 @@ module "cert_manager_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "~> 5.0"
 
-  role_name = "cert-manager-${local.vars.id}"
+  role_name = "cert-manager-${local.install_name}"
 
-  attach_cert_manager_policy    = true
+  attach_cert_manager_policy = true
   cert_manager_hosted_zone_arns = [
     aws_route53_zone.internal.arn,
     aws_route53_zone.public.arn,

--- a/aws-eks-byovpc/ebs-csi.tf
+++ b/aws-eks-byovpc/ebs-csi.tf
@@ -9,7 +9,7 @@ module "ebs_csi_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "~> 5.0"
 
-  role_name             = "ebs-csi-${local.vars.id}"
+  role_name             = "ebs-csi-${local.install_name}"
   attach_ebs_csi_policy = true
 
   oidc_providers = {

--- a/aws-eks-byovpc/ecr.tf
+++ b/aws-eks-byovpc/ecr.tf
@@ -9,7 +9,7 @@ module "ecr" {
   create_lifecycle_policy                   = false
   create_registry_replication_configuration = false
 
-  repository_name                 = local.vars.id
+  repository_name                 = local.install_name
   repository_image_tag_mutability = "MUTABLE"
   repository_encryption_type      = "KMS"
   repository_image_scan_on_push   = false

--- a/aws-eks-byovpc/eks.tf
+++ b/aws-eks-byovpc/eks.tf
@@ -44,7 +44,7 @@ resource "aws_kms_key" "eks" {
 
 # TODO: Looks like we're not using this?
 # resource "aws_kms_alias" "eks" {
-#   name          = "alias/nuon/eks-${local.vars.id}"
+#   name          = "alias/nuon/eks-${local.install_name}"
 #   target_key_id = aws_kms_key.eks.id
 # }
 
@@ -101,7 +101,7 @@ module "eks" {
 
   # HACK: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1986
   node_security_group_tags = {
-    "kubernetes.io/cluster/${local.vars.id}" = null
+    "kubernetes.io/cluster/${local.install_name}" = null
   }
 
   # this can't rely on default_tags.

--- a/aws-eks-byovpc/odr.tf
+++ b/aws-eks-byovpc/odr.tf
@@ -7,7 +7,7 @@ data "aws_iam_policy_document" "odr" {
 }
 
 resource "aws_iam_policy" "odr" {
-  name   = "odr-${local.vars.id}"
+  name   = "odr-${local.install_name}"
   policy = data.aws_iam_policy_document.odr.json
 }
 
@@ -20,11 +20,11 @@ module "odr_iam_role" {
   version     = ">= 5.1.0"
   create_role = true
 
-  role_name = "odr-${local.vars.id}"
+  role_name = "odr-${local.install_name}"
   role_path = "/nuon/"
 
   cluster_service_accounts = {
-    (local.vars.id) = ["${var.waypoint_odr_namespace}:${var.waypoint_odr_service_account_name}"]
+    (local.install_name) = ["${var.waypoint_odr_namespace}:${var.waypoint_odr_service_account_name}"]
   }
 
   role_policy_arns = {

--- a/aws-eks-byovpc/outputs.tf
+++ b/aws-eks-byovpc/outputs.tf
@@ -47,7 +47,7 @@ output "ecr" {
   value = {
     repository_url  = module.ecr.repository_url
     repository_arn  = module.ecr.repository_arn
-    repository_name = local.vars.id
+    repository_name = local.install_name
     registry_id     = module.ecr.repository_registry_id
     registry_url    = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${var.region}.amazonaws.com"
   }

--- a/aws-eks-byovpc/variables.tf
+++ b/aws-eks-byovpc/variables.tf
@@ -13,7 +13,6 @@ locals {
   /* } */
 
   vars = {
-    id     = local.install_name
     region = var.region
   }
 }


### PR DESCRIPTION
local.vars.id was the same as nuon_id, and made updating naming the install kind of a pain.