### PR TITLE
refactor(aws-eks-byovpc): remove local.vars

### DIFF
--- a/aws-eks-byovpc/cert-manager-issuers.tf
+++ b/aws-eks-byovpc/cert-manager-issuers.tf
@@ -34,7 +34,7 @@ resource "kubectl_manifest" "internal_cluster_issuer" {
             }
             dns01 = {
               route53 = {
-                region = local.vars.region
+                region = local.install_region
                 hostedZoneID : aws_route53_zone.internal.zone_id,
               }
             }
@@ -73,7 +73,7 @@ resource "kubectl_manifest" "public_cluster_issuer" {
             }
             dns01 = {
               route53 = {
-                region = local.vars.region
+                region = local.install_region
                 hostedZoneID : aws_route53_zone.public.zone_id
               }
             }

--- a/aws-eks-byovpc/provider.tf
+++ b/aws-eks-byovpc/provider.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 provider "aws" {
-  region = local.vars.region
+  region = local.install_region
 
   assume_role {
     role_arn = var.assume_role_arn
@@ -21,7 +21,7 @@ provider "aws" {
 
 # hack. see eks.tf for more details
 provider "aws" {
-  region = local.vars.region
+  region = local.install_region
   alias  = "no_tags"
 
   assume_role {

--- a/aws-eks-byovpc/variables.tf
+++ b/aws-eks-byovpc/variables.tf
@@ -2,7 +2,8 @@ locals {
 
   install_name = var.cluster_name
 
-  tags = merge({ nuon_id = local.install_name }, var.tags)
+  install_region = var.region
+  tags           = merge({ nuon_id = local.install_name }, var.tags)
 
   /* external_dns = { */
   /*   registry           = "txt" */


### PR DESCRIPTION
A local named "vars" was declared with a bunch of global values. It made things kind of confusing. In some cases we were using vars directly, in some cases locals, and in other "local.vars".