### PR TITLE
feat(aws-eks-byovpc): accept install_name var

### DIFF
--- a/aws-eks-byovpc/eks.tf
+++ b/aws-eks-byovpc/eks.tf
@@ -1,5 +1,5 @@
 locals {
-  cluster_name    = var.cluster_name
+  cluster_name    = local.install_name
   cluster_version = var.eks_version
 
   instance_types = var.instance_types

--- a/aws-eks-byovpc/variables.tf
+++ b/aws-eks-byovpc/variables.tf
@@ -1,7 +1,5 @@
 locals {
-
-  install_name = var.cluster_name
-
+  install_name   = (var.install_name != "" ? var.install_name : var.cluster_name)
   install_region = var.region
   tags           = merge({ nuon_id = local.install_name }, var.tags)
 
@@ -12,10 +10,12 @@ locals {
   /*   triggerLoopOnEvent = true */
   /*   interval           = "15m" */
   /* } */
+}
 
-  vars = {
-    region = var.region
-  }
+variable "install_name" {
+  type        = string
+  description = "The name of this install. Will be used for the EKS cluster, various tags, and other resources."
+  default     = ""
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
cluster_name was effectively being used as the name of the entire install, so this should make that clear.