### PR TITLE
feat: add runner identity, and private endpoints

### DIFF
--- a/azure-aks/network.tf
+++ b/azure-aks/network.tf
@@ -21,9 +21,7 @@ module "network" {
   subnet_names        = local.subnet_names
 
   subnet_service_endpoints = {
-    "subnet1" : ["Microsoft.Sql"],
-    "subnet2" : ["Microsoft.Sql"],
-    "subnet3" : ["Microsoft.Sql"]
+    (local.subnet_names[2]) : ["Microsoft.Storage", "Microsoft.Sql"],
   }
   use_for_each = true
   tags = {
@@ -33,10 +31,3 @@ module "network" {
 
   depends_on = [azurerm_resource_group.rg]
 }
-
-#resource "azurerm_subnet" "appgw" {
-  #address_prefixes     = [local.appgw_cidr]
-  #name                 = "${var.nuon_id}-gw"
-  #resource_group_name = azurerm_resource_group.rg.name
-  #virtual_network_name = module.network.vnet_name
-#}

--- a/azure-aks/runner.tf
+++ b/azure-aks/runner.tf
@@ -1,0 +1,28 @@
+data "azurerm_subscription" "main" {}
+
+resource "azurerm_role_definition" "runner" {
+  name        = "${var.nuon_id}-runner"
+  scope       = data.azurerm_subscription.main.id
+  description = "Role used by runner to manage the account."
+
+  permissions {
+    actions     = ["*"]
+    not_actions = []
+  }
+
+  assignable_scopes = [
+    data.azurerm_subscription.main.id,
+  ]
+}
+
+resource "azurerm_user_assigned_identity" "managed_identity" {
+  name                = "${var.nuon_id}-runner"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+resource "azurerm_role_assignment" "assign_identity_storage_blob_data_contributor" {
+  scope                = data.azurerm_subscription.main.id
+  role_definition_name = azurerm_role_definition.runner.name
+  principal_id         = azurerm_user_assigned_identity.managed_identity.principal_id
+}

--- a/azure-aks/versions.tf
+++ b/azure-aks/versions.tf
@@ -1,6 +1,5 @@
 terraform {
-  // TODO: uncomment when done testing
-  backend "s3" {}
+  backend "local" {}
 
   required_providers {
     azapi = {

--- a/azure-aks/versions.tf
+++ b/azure-aks/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  backend "local" {}
+  backend "s3" {}
 
   required_providers {
     azapi = {


### PR DESCRIPTION
This PR adds the runner identity, granting AKS permissions as well as updates vnet to provision private endpoints.
