### PR TITLE
feat: update private endpoint, node groups and more

### DIFF
--- a/azure-aks/aks.tf
+++ b/azure-aks/aks.tf
@@ -1,3 +1,7 @@
+locals {
+  runner_vm_size = "Standard_D2s_v3"
+}
+
 module "aks" {
   source = "Azure/aks/azurerm"
 
@@ -48,6 +52,23 @@ module "aks" {
   vnet_subnet_id                                  = module.network.vnet_subnets[0]
   attached_acr_id_map = {
     "${azurerm_container_registry.acr.name}" = azurerm_container_registry.acr.id
+  }
+
+  node_pools = {
+    "runner" = {
+      name = "runner"
+      vm_size = local.runner_vm_size
+      node_count = 1
+      vnet_subnet_id = module.network.vnet_subnets[0]
+      create_before_destroy = true
+    }
+    "default" = {
+      name = "default"
+      vm_size = var.vm_size
+      node_count = var.node_count
+      vnet_subnet_id = module.network.vnet_subnets[0]
+      create_before_destroy = true
+    }
   }
 
   depends_on = [

--- a/azure-aks/data.tf
+++ b/azure-aks/data.tf
@@ -1,0 +1,1 @@
+data "azurerm_client_config" "current" {}

--- a/azure-aks/dns.tf
+++ b/azure-aks/dns.tf
@@ -1,0 +1,9 @@
+resource "azurerm_dns_zone" "public" {
+  name                = var.public_root_domain
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+resource "azurerm_private_dns_zone" "internal" {
+  name                = var.internal_root_domain
+  resource_group_name = azurerm_resource_group.rg.name
+}

--- a/azure-aks/network.tf
+++ b/azure-aks/network.tf
@@ -23,6 +23,10 @@ module "network" {
   subnet_service_endpoints = {
     (local.subnet_names[2]) : ["Microsoft.Storage", "Microsoft.Sql"],
   }
+  subnet_enforce_private_link_endpoint_network_policies = {
+    (local.subnet_names[2]) : true
+  }
+
   use_for_each = true
   tags = {
     environment = "dev"

--- a/azure-aks/network.tf
+++ b/azure-aks/network.tf
@@ -21,9 +21,7 @@ module "network" {
   subnet_names        = local.subnet_names
 
   subnet_service_endpoints = {
-    "subnet1" : ["Microsoft.Sql"],
-    "subnet2" : ["Microsoft.Sql"],
-    "subnet3" : ["Microsoft.Sql"]
+    (local.subnet_names[2]) : ["Microsoft.Storage", "Microsoft.Sql"],
   }
   use_for_each = true
   tags = {
@@ -33,10 +31,3 @@ module "network" {
 
   depends_on = [azurerm_resource_group.rg]
 }
-
-#resource "azurerm_subnet" "appgw" {
-  #address_prefixes     = [local.appgw_cidr]
-  #name                 = "${var.nuon_id}-gw"
-  #resource_group_name = azurerm_resource_group.rg.name
-  #virtual_network_name = module.network.vnet_name
-#}

--- a/azure-aks/outputs.tf
+++ b/azure-aks/outputs.tf
@@ -9,6 +9,22 @@ output "vpn" {
   }
 }
 
+output "public_domain" {
+  value = {
+    nameservers = azurerm_dns_zone.public.name_servers
+    name = azurerm_dns_zone.public.name
+    id = azurerm_dns_zone.public.id
+  }
+}
+
+output "internal_domain" {
+  value = {
+    nameservers = []
+    name = azurerm_private_dns_zone.internal.name
+    id = azurerm_private_dns_zone.internal.id
+  }
+}
+
 output "account" {
   value = {
     "location" = var.location

--- a/azure-aks/outputs.tf
+++ b/azure-aks/outputs.tf
@@ -9,6 +9,15 @@ output "vpn" {
   }
 }
 
+output "account" {
+  value = {
+    "location" = var.location
+    "subscription_id" = data.azurerm_client_config.current.subscription_id
+    "client_id" = data.azurerm_client_config.current.client_id
+    "resource_group_name" = azurerm_resource_group.rg.name
+  }
+}
+
 output "acr" {
   value = {
     id = azurerm_container_registry.acr.id

--- a/azure-aks/runner.tf
+++ b/azure-aks/runner.tf
@@ -1,0 +1,28 @@
+data "azurerm_subscription" "main" {}
+
+resource "azurerm_role_definition" "runner" {
+  name        = "${var.nuon_id}-runner"
+  scope       = data.azurerm_subscription.main.id
+  description = "Role used by runner to manage the account."
+
+  permissions {
+    actions     = ["*"]
+    not_actions = []
+  }
+
+  assignable_scopes = [
+    data.azurerm_subscription.main.id,
+  ]
+}
+
+resource "azurerm_user_assigned_identity" "managed_identity" {
+  name                = "${var.nuon_id}-runner"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+resource "azurerm_role_assignment" "assign_identity_storage_blob_data_contributor" {
+  scope                = data.azurerm_subscription.main.id
+  role_definition_name = azurerm_role_definition.runner.name
+  principal_id         = azurerm_user_assigned_identity.managed_identity.principal_id
+}

--- a/azure-aks/variables.tf
+++ b/azure-aks/variables.tf
@@ -13,6 +13,13 @@ variable "location" {
   description = "The location to launch the cluster in"
 }
 
+variable "access_group_users" {
+  type = list(string)
+  default = ["jon@nuon.co"]
+  description = "List of emails that will have access to the install"
+}
+
+
 // NOTE: if you would like to create an internal load balancer, with TLS, you will have to use the public domain.
 variable "internal_root_domain" {
   type        = string

--- a/azure-aks/versions.tf
+++ b/azure-aks/versions.tf
@@ -1,6 +1,5 @@
 terraform {
-  // TODO: uncomment when done testing
-  backend "s3" {}
+  backend "local" {}
 
   required_providers {
     azapi = {

--- a/azure-aks/versions.tf
+++ b/azure-aks/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  #backend "s3" {}
+  backend "s3" {}
 
   required_providers {
     azapi = {

--- a/azure-aks/versions.tf
+++ b/azure-aks/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  backend "local" {}
+  backend "s3" {}
 
   required_providers {
     azapi = {

--- a/azure-aks/versions.tf
+++ b/azure-aks/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  backend "s3" {}
+  #backend "s3" {}
 
   required_providers {
     azapi = {


### PR DESCRIPTION
This PR adds several improvements to the `azure-aks` sandbox:

- implements the dns zones
- implements a runner specific node group, to isolate the runner
- configures private endpoints for blob and sql