### PR TITLE
chore: aws-eks/pre-destroy.sh: handle case where ns dne

### DIFF
--- a/aws-eks/pre-destroy.sh
+++ b/aws-eks/pre-destroy.sh
@@ -2,8 +2,9 @@
 
 set -u
 set -o pipefail
+set -e
 
 
 echo "executing error-destroy script"
 aws eks update-kubeconfig --name $NUON_INSTALL_ID --alias $NUON_INSTALL_ID
-kubectl delete namespace $NUON_INSTALL_ID
+kubectl delete namespace $NUON_INSTALL_ID --ignore-not-found=true


### PR DESCRIPTION
it is possible this script may run twice so we must be prepared to
handle the case where the namespace no longer exists.
