### PR TITLE
chore: aws-eks: update to 1.6.1

### DIFF
--- a/aws-eks/sandbox.tf
+++ b/aws-eks/sandbox.tf
@@ -2,7 +2,7 @@ module "sandbox" {
   # NOTE(fd): example format for testing branches
   # source = "github.com/nuonco/terraform-aws-eks-sandbox?ref=e4c8e0feda3b80c84bb32a170f8969194160b621"
   source  = "nuonco/eks-sandbox/aws"
-  version = "1.5.6"
+  version = "1.6.1"
 
   install_name          = var.install_name
   cluster_name          = var.cluster_name


### PR DESCRIPTION
Changelog
1. Admin Access Role support.
2. All TF Modules tagged w/ local.tags
3. ALB Ingress Controller defaultTags for all resources it manages
